### PR TITLE
Fixes Invalid Regex Group

### DIFF
--- a/lib/star.coffee
+++ b/lib/star.coffee
@@ -129,7 +129,9 @@ class Star
       @latestRowSeen = row
 
   _starIndexOf: (line) ->
-    match = /(?<=^\s*)([\*\-\+]|\d+\.)/.exec(line)
+    match = /^\s*([\*\-\+]|\d+\.)/.exec(line)
+    console.log("_starIndexOf: "+line)
+    console.log(match)
     return match.index
 
   newStarLine: (indentLevel = @indentLevel) ->

--- a/lib/star.coffee
+++ b/lib/star.coffee
@@ -129,10 +129,11 @@ class Star
       @latestRowSeen = row
 
   _starIndexOf: (line) ->
-    match = /^\s*([\*\-\+]|\d+\.)/.exec(line)
-    console.log("_starIndexOf: "+line)
-    console.log(match)
-    return match.index
+    match = /^(\s*)([\*\-\+]|\d+\.)/.exec(line)
+    # No match, ignore
+    return 0 if match.length < 1
+    # count the spaces
+    return match[1].length
 
   newStarLine: (indentLevel = @indentLevel) ->
     if @indentType isnt "mixed"

--- a/spec/new-line-spec.coffee
+++ b/spec/new-line-spec.coffee
@@ -8,10 +8,10 @@ describe "Pressing ctrl-enter creates a new line indented to the text", ->
     waitsForPromise ->
       atom.packages.activatePackage('organized')
 
-  parameterized = (cursorPos, finalCursorPos, before, after, newLevelStyle='whitespace') ->
+  parameterized = (title,cursorPos, finalCursorPos, before, after, newLevelStyle='whitespace') ->
     describe "organized:newLine", ->
 
-      it "should indent properly", ->
+      it "should indent properly for "+title, ->
         console.log("Testing\n#{before}\n<<becomes>>\n#{after}")
         atom.config.set('organized.levelStyle', newLevelStyle)
         editor = atom.workspace.getActiveTextEditor()
@@ -26,19 +26,19 @@ describe "Pressing ctrl-enter creates a new line indented to the text", ->
         expect(newCursorPosition.column).toBe(finalCursorPos[1])
 
   # Single level, multiple styles
-  parameterized([0,5], [1,2], "* One", "* One\n  ")
-  parameterized([0,5], [1,2], "- One", "- One\n  ")
-  parameterized([0,5], [1,2], "+ One", "+ One\n  ")
+  parameterized("level 1 star",[0,5], [1,2], "* One", "* One\n  ")
+  parameterized("level 1 line",[0,5], [1,2], "- One", "- One\n  ")
+  parameterized("level 1 plus",[0,5], [1,2], "+ One", "+ One\n  ")
 
-  parameterized([1,7], [2,4], "* One\n  * Two", "* One\n  * Two\n    ")
-  parameterized([1,7], [2,4], "- One\n  - Two", "- One\n  - Two\n    ")
-  parameterized([1,7], [2,4], "+ One\n  + Two", "+ One\n  + Two\n    ")
+  parameterized("level 2 star",[1,7], [2,4], "* One\n  * Two", "* One\n  * Two\n    ")
+  parameterized("level 2 line",[1,7], [2,4], "- One\n  - Two", "- One\n  - Two\n    ")
+  parameterized("level 2 plus",[1,7], [2,4], "+ One\n  + Two", "+ One\n  + Two\n    ")
 
   # Same with tabs
-  parameterized([0,5], [1,2], "* One", "* One\n  ", 'tabs')
-  parameterized([0,5], [1,2], "- One", "- One\n  ", 'tabs')
-  parameterized([0,5], [1,2], "+ One", "+ One\n  ", 'tabs')
+  parameterized("level 1 star with tabs",[0,5], [1,2], "* One", "* One\n  ", 'tabs')
+  parameterized("level 1 line with tabs",[0,5], [1,2], "- One", "- One\n  ", 'tabs')
+  parameterized("level 1 plus with tabs",[0,5], [1,2], "+ One", "+ One\n  ", 'tabs')
 
-  parameterized([1,7], [2,3], "* One\n\t* Two", "* One\n\t* Two\n\t  ", 'tabs')
-  parameterized([1,7], [2,3], "- One\n\t- Two", "- One\n\t- Two\n\t  ", 'tabs')
-  parameterized([1,7], [2,3], "+ One\n\t+ Two", "+ One\n\t+ Two\n\t  ", 'tabs')
+  parameterized("level 2 star with tabs",[1,7], [2,3], "- One\n\t- Two", "- One\n\t- Two\n\t  ", 'tabs')
+  parameterized("level 2 line with tabs",[1,7], [2,3], "+ One\n\t+ Two", "+ One\n\t+ Two\n\t  ", 'tabs')
+  parameterized("level 2 plus with tabs",[1,7], [2,3], "* One\n\t* Two", "* One\n\t* Two\n\t  ", 'tabs')


### PR DESCRIPTION
This PR fixes #5 

Atom's (maybe javascript's) regex engine doesn't allow dynamic width look-behind.  This was fixed by matching on the whitespace and counting them.

All the failed specs now pass except for one related to stars in code blocks.  This is not a feature that I need so I have investigated it, but it does not appear to be caused by function that I fixed.